### PR TITLE
increate spotify playlist limit

### DIFF
--- a/src/playify/services/platforms.py
+++ b/src/playify/services/platforms.py
@@ -29,7 +29,7 @@ async def process_spotify_url(url, interaction):
                     lambda: sp.playlist_items(
                         clean_url,
                         fields="items.track.name,items.track.artists.name,next",
-                        limit=100,
+                        limit=10000,
                     ),
                 )
                 while results:


### PR DESCRIPTION
when trying to play a large playlist, it only loads 100 songs, now its set to 10,000