### PR TITLE
fix: NameError when opening up settings menu

### DIFF
--- a/src/tui/settings_menu.py
+++ b/src/tui/settings_menu.py
@@ -1,33 +1,41 @@
 """Settings Menu Wizard for Playify."""
 
-import os
-import json
-from pathlib import Path
-import traceback
+from rich import box
 from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Prompt, IntPrompt
-from rich.text import Text
 from rich.table import Table
+from rich.text import Text
 
 # Try to use theme from tui if available
 try:
     from .theme import (
-        PLAYIFY_THEME, BLUE_ICE, BLUE_LIGHT, BLUE_NAVY, BLUE_DEEP, 
+        PLAYIFY_THEME, BLUE_ICE, BLUE_LIGHT, BLUE_NAVY, BLUE_DEEP,
         STEEL, WHITE, GRAY_DARK, ICON_GEAR, ICON_PLAY, BOX_TL, BOX_TR, BOX_BL, BOX_BR, BOX_H, BOX_V
     )
 except ImportError:
     from rich.theme import Theme
+
     PLAYIFY_THEME = Theme({})
     BLUE_ICE, BLUE_LIGHT, BLUE_NAVY, BLUE_DEEP, STEEL, WHITE, GRAY_DARK = "cyan", "blue", "blue", "blue", "grey70", "white", "grey30"
     ICON_GEAR, ICON_PLAY, BOX_TL, BOX_TR, BOX_BL, BOX_BR, BOX_H, BOX_V = "#", ">", "+", "+", "+", "+", "-", "|"
 
 from ..playify.config import Config
 
+from rich.align import Align
+
+
 def clear_screen(console: Console):
     console.clear()
-    
-from rich.align import Align
+
+
+STATUS_TYPES = {
+    0: "Playing",
+    2: "Listening",
+    3: "Watching",
+    5: "Competing"
+}
+
 
 def print_banner(console: Console):
     header_text = Text()
@@ -46,41 +54,27 @@ def print_banner(console: Console):
     )
     console.print(panel)
 
-    st_type = STATUS_TYPES.get(Config.get("bot_status_type"), "Unknown")
-    bot_status_text = Config.get("bot_status_text")
-    st_text = bot_status_text if bot_status_text else f"[{GRAY_DARK}]<None>[/]"
-    
-    table.add_row(f"[{BLUE_ICE}][ 1 ][/]", "Bot Status Text", st_text)
-    table.add_row(f"[{BLUE_ICE}][ 2 ][/]", "Bot Status Type", f"{st_type} (Code {Config.get('bot_status_type')})")
-    table.add_row(f"[{BLUE_ICE}][ 3 ][/]", "Controller Idle Image URL", Config.get("controller_idle_image"))
+
 def draw_menu(console: Console):
     clear_screen(console)
     print_banner(console)
     console.print()
-    
-    from rich import box
+
     table = Table(show_header=False, box=box.SIMPLE_HEAD, padding=(0, 3))
     table.add_column("Key", style=f"bold {BLUE_LIGHT}", justify="right")
     table.add_column("Description", style=STEEL)
     table.add_column("Current Value", style=f"bold {WHITE}")
-    
-    STATUS_TYPES = {
-        0: "Playing",
-        2: "Listening",
-        3: "Watching",
-        5: "Competing"
-    }
 
     st_type = STATUS_TYPES.get(Config.get("bot_status_type"), "Unknown")
     bot_status_text = Config.get("bot_status_text")
     st_text = bot_status_text if bot_status_text else f"[{GRAY_DARK}]<None>[/]"
-    
+
     table.add_row(f"[{BLUE_ICE}][ 1 ][/]", "Bot Status Text", st_text)
     table.add_row(f"[{BLUE_ICE}][ 2 ][/]", "Bot Status Type", f"{st_type} (Code {Config.get('bot_status_type')})")
     table.add_row(f"[{BLUE_ICE}][ 3 ][/]", "Controller Idle Image URL", Config.get("controller_idle_image"))
     table.add_row("", "", "")
     table.add_row(f"[{BLUE_ICE}][ 0 ][/]", "Return to Dashboard", "")
-    
+
     panel = Panel(
         table,
         title=f"[bold {WHITE}] {ICON_GEAR} Configuration Menu [/]",
@@ -89,42 +83,48 @@ def draw_menu(console: Console):
     )
     console.print(panel, justify="center")
 
+
 def run_settings_menu():
     console = Console(theme=PLAYIFY_THEME)
     Config.reload()
-    
+
     while True:
         draw_menu(console)
-        
+
         console.print()
-        choice = Prompt.ask(f"  [bold {BLUE_ICE}]{ICON_PLAY} Select an option[/]", choices=["1", "2", "3", "0"], default="0")
-        
+        choice = Prompt.ask(f"  [bold {BLUE_ICE}]{ICON_PLAY} Select an option[/]", choices=["1", "2", "3", "0"],
+                            default="0")
+
         if choice == "0":
             break
-            
+
         elif choice == "1":
             console.print(f"\n  [{STEEL}]Current text:[/] {Config.get('bot_status_text') or '<None>'}")
-            console.print(f"  [{GRAY_DARK}](To remove the status completely, just type the word 'none' or leave empty)[/]")
+            console.print(
+                f"  [{GRAY_DARK}](To remove the status completely, just type the word 'none' or leave empty)[/]")
             new_val = Prompt.ask(f"  [bold {BLUE_LIGHT}]Enter new status text[/]")
             if new_val.strip().lower() == "none" or new_val == "":
                 Config.set("bot_status_text", "")
             else:
                 Config.set("bot_status_text", new_val.strip())
-                
+
         elif choice == "2":
             console.print(f"\n  [{STEEL}]Available types:[/] 0=Playing, 2=Listening, 3=Watching, 5=Competing")
-            new_val = IntPrompt.ask(f"  [bold {BLUE_LIGHT}]Enter new status type[/]", choices=["0", "2", "3", "5"], default=Config.get('bot_status_type'))
+            new_val = IntPrompt.ask(f"  [bold {BLUE_LIGHT}]Enter new status type[/]", choices=["0", "2", "3", "5"],
+                                    default=Config.get('bot_status_type'))
             Config.set("bot_status_type", new_val)
-            
+
         elif choice == "3":
             console.print(f"\n  [{STEEL}]Current URL:[/] {Config.get('controller_idle_image')}")
-            new_val = Prompt.ask(f"  [bold {BLUE_LIGHT}]Enter new image URL (must be a direct link, e.g., .png/.jpg)[/]")
+            new_val = Prompt.ask(
+                f"  [bold {BLUE_LIGHT}]Enter new image URL (must be a direct link, e.g., .png/.jpg)[/]")
             if new_val.strip() and new_val.startswith("http"):
                 Config.set("controller_idle_image", new_val.strip())
             elif new_val.strip():
                 console.print(f"  [bold red]Invalid URL![/] Must start with http/https.", style="error")
                 import time
                 time.sleep(2)
+
 
 if __name__ == "__main__":
     run_settings_menu()


### PR DESCRIPTION
When opening the settings menu by pressing S, this error is thrown:
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/bobby/playify/src/tui/__main__.py", line 262, in <module>
    main()
  File "/home/bobby/playify/src/tui/__main__.py", line 224, in main
    run_settings_menu()
  File "/home/bobby/playify/src/tui/settings_menu.py", line 97, in run_settings_menu
    draw_menu(console)
  File "/home/bobby/playify/src/tui/settings_menu.py", line 58, in draw_menu
    print_banner(console)
  File "/home/bobby/playify/src/tui/settings_menu.py", line 49, in print_banner
    st_type = STATUS_TYPES.get(Config.get("bot_status_type"), "Unknown")
              ^^^^^^^^^^^^
NameError: name 'STATUS_TYPES' is not defined
```

A fix is applied by removing the duplicate (and possibly redundant) printing of the bot's current settings, in `src/tui/settings_menu.py`, between lines 49 and 55:
```
...
    st_type = STATUS_TYPES.get(Config.get("bot_status_type"), "Unknown")
    bot_status_text = Config.get("bot_status_text")
    st_text = bot_status_text if bot_status_text else f"[{GRAY_DARK}]<None>[/]"
    
    table.add_row(f"[{BLUE_ICE}][ 1 ][/]", "Bot Status Text", st_text)
    table.add_row(f"[{BLUE_ICE}][ 2 ][/]", "Bot Status Type", f"{st_type} (Code {Config.get('bot_status_type')})")
    table.add_row(f"[{BLUE_ICE}][ 3 ][/]", "Controller Idle Image URL", Config.get("controller_idle_image"))
```

STATUS_TYPES is also a constant dictionary, which should not be declared within a function, similar to the import `from rich import box` which should also not be declared within a function, but at the start of the file instead. (See [PEP 8](https://peps.python.org/pep-0008/))
Some redundant (presumably) imports were also removed from the start of the file.
 